### PR TITLE
Change letter 'O' to numerical '0' in address

### DIFF
--- a/scaling/ipv6.rst
+++ b/scaling/ipv6.rst
@@ -160,7 +160,7 @@ address. An example would be
 
 ::
 
-   47CD:1234:4422:ACO2:0022:1234:A456:0124
+   47CD:1234:4422:AC02:0022:1234:A456:0124
 
 Any IPv6 address can be written using this notation. Since there are a
 few special types of IPv6 addresses, there are some special notations


### PR DESCRIPTION
An eagle-eyed student pointed out that this address isn't valid hexadecimal due to an 'O' being included in place of a '0'. This change corrects the typo.