### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx~=1.8.5
+Sphinx~=4.2.0
 actdiag~=0.5.4
 blockdiag~=1.5.4
 livereload~=2.6.1


### PR DESCRIPTION
`make html` fails with `Sphinx~=1.8.5` because of a jinja2 dependency problem. Check here for reference https://github.com/readthedocs/readthedocs.org/issues/9037