### PR TITLE
change u_char to uint8_t in Chapter 2

### DIFF
--- a/direct/reliable.rst
+++ b/direct/reliable.rst
@@ -338,12 +338,12 @@ that indicates whether the frame is an ACK or carries data.
 
 .. code-block:: c
 
-   typedef u_char SwpSeqno;
+   typedef uint8_t SwpSeqno;
 
    typedef struct {
        SwpSeqno   SeqNum;   /* sequence number of this frame */
        SwpSeqno   AckNum;   /* ack of received frame */
-       u_char     Flags;           /* up to 8 bits worth of flags */
+       uint8_t     Flags;   /* up to 8 bits worth of flags */
    } SwpHdr;
 
 Next, the state of the sliding window algorithm has the following


### PR DESCRIPTION
In the sliding window section of chapter 2 of the book, there's a code block that describes a sliding window algorithm. It uses a type called `u_char` which I assume is meant to tell the reader to use an 8-bit unsigned char type. `u_char` isn't a standard type, so I changed it to `uint8_t` from `stdint.h` in this PR, so this code will compile (if you include `stdint.h` from ANSI C99) and reads a bit better.