### PR TITLE
Correcting HTTP examples to match RFC

### DIFF
--- a/applications/traditional.rst
+++ b/applications/traditional.rst
@@ -560,17 +560,16 @@ For example, the ``START_LINE``
 
 ::
 
-   GET http://www.cs.princeton.edu/index.html
-   HTTP/1.1
+   GET http://www.cs.princeton.edu/index.html HTTP/1.1
 
 says that the client wants the server on host to return the page named
-``index.html``.  This particular example uses an *absolute* URL. It is
-also possible to use a *relative* identifier and specify the host name
+``index.html``.  This particular example uses an absolute URL. It is
+also possible to request a path in the ``START_LINE` and specify the host name
 in one of the ``MESSAGE_HEADER`` lines; for example,
 
 .. code-block:: http
 
-   GET index.html HTTP/1.1
+   GET /index.html HTTP/1.1
    Host: www.cs.princeton.edu
 
 Here, ``Host`` is one of the possible ``MESSAGE_HEADER`` fields. One

--- a/applications/traditional.rst
+++ b/applications/traditional.rst
@@ -564,7 +564,7 @@ For example, the ``START_LINE``
 
 says that the client wants the server on host to return the page named
 ``index.html``.  This particular example uses an absolute URL. It is
-also possible to request a path in the ``START_LINE` and specify the host name
+also possible to request a path in the ``START_LINE`` and specify the host name
 in one of the ``MESSAGE_HEADER`` lines; for example,
 
 .. code-block:: http


### PR DESCRIPTION
The protocol version must be in the start line, not on the next line. If requesting a path, it must be an absolute path. Fixes #64.