### PR TITLE
Fix calculation about average time required for brute force attack

### DIFF
--- a/security/crypto.rst
+++ b/security/crypto.rst
@@ -87,7 +87,7 @@ attacker could be so lucky as to try the correct value immediately, or
 so unlucky as to try every incorrect value before finally trying the
 correct value of the key, having tried all 2\ :sup:`n` possible
 values; the average number of guesses to discover the correct value is
-halfway between those extremes, 2\ :sup:`n/2`.  This can be made
+halfway between those extremes, 2\ :sup:`n-1`.  This can be made
 computationally impractical by choosing a sufficiently large key space
 and by making the operation of checking a key reasonably costly. What
 makes this difficult is that computing speeds keep increasing, making


### PR DESCRIPTION
Half way between `1` and `2^n` is `2^(n-1)` or `(2^n)/2`, not `2^(n/2)`.