### PR TITLE
fix compilation errors from `server.c` example

### DIFF
--- a/foundation/software.rst
+++ b/foundation/software.rst
@@ -353,7 +353,7 @@ out the characters that arrive on the connection.
          perror("simplex-talk: accept");
          exit(1);
        }
-       while (buf_len == recv(new_s, buf, sizeof(buf), 0))
+       while (buf_len = recv(new_s, buf, sizeof(buf), 0))
          fputs(buf, stdout);
        close(new_s);
      }

--- a/foundation/software.rst
+++ b/foundation/software.rst
@@ -326,7 +326,8 @@ out the characters that arrive on the connection.
    {
      struct sockaddr_in sin;
      char buf[MAX_LINE];
-     int buf_len, addr_len;
+     int buf_len;
+     socklen_t addr_len;
      int s, new_s;
 
      /* build address data structure */
@@ -352,7 +353,7 @@ out the characters that arrive on the connection.
          perror("simplex-talk: accept");
          exit(1);
        }
-       while (buf_len = recv(new_s, buf, sizeof(buf), 0))
+       while (buf_len == recv(new_s, buf, sizeof(buf), 0))
          fputs(buf, stdout);
        close(new_s);
      }


### PR DESCRIPTION
Server code example has some errors that I fixed on the PR
- updated `addr_len` to use type `socklen_t`
- fix the while condition to use `==` instead of `=`