### PR TITLE
fix transmit calculations

### DIFF
--- a/foundation/performance.rst
+++ b/foundation/performance.rst
@@ -130,18 +130,18 @@ application will perform much differently on a transcontinental channel
 with a 100-ms RTT than it will on an across-the-room channel with a
 1-ms RTT. Whether the channel is 1 Mbps or 100 Mbps is relatively
 insignificant, however, since the former implies that the time to
-transmit a byte (``Transmit``) is 8 μs and the latter implies
-``Transmit`` = 0.08 μs.
+transmit a byte (``Transmit``) is 1 μs and the latter implies
+``Transmit`` = 0.01 μs.
 
 In contrast, consider a digital library program that is being asked to
 fetch a 25-megabyte (MB) image—the more bandwidth that is available, the
 faster it will be able to return the image to the user. Here, the
 bandwidth of the channel dominates performance. To see this, suppose
-that the channel has a bandwidth of 10 Mbps. It will take 20 seconds to
+that the channel has a bandwidth of 10 Mbps. It will take 2.5 seconds to
 transmit the image (25 × 10\ :sup:`6` × 8-bits / (10 × 10\ :sup:`6`
-Mbps = 20 seconds), making it relatively unimportant if the image
+× 8-bits = 2.5 seconds), making it relatively unimportant if the image
 is on the other side of a 1-ms channel or a 100-ms channel; the difference
-between a 20.001-second response time and a 20.1-second response time is
+between a 2.501-second response time and a 2.6-second response time is
 negligible.
 
 .. _fig-latency:


### PR DESCRIPTION
# [performance.rst corrections](https://github.com/SystemsApproach/book/blob/master/foundation/performance.rst)

1. https://github.com/SystemsApproach/book/pull/81/commits/c9bda5af4dab9babd4725808cc4a3bac24cd584d
   1. Transmit 1 byte with 1 mbs: `transmit` = 1 byte / (1e6 bytes / 1 second) = 0.000001 seconds = 0.001 ms = 1 μs
   1. Transmit 25 Mbs with 10 Mbs: `transmit` = 25e6 / ( 10e6 / 1 second)  = 2.5 seconds
   1. 2.501-second response time and a 2.6-second response time for 1ms and 100ms channel respectively
1. https://github.com/SystemsApproach/book/pull/81/commits/36cce78faa8d73c093eb297451123c723974052e
   1. 50 x 10^-3 sec × 45 x 10^6 *bytes/sec* = 2.25 x 10^6 *bytes*
   1. 5.5 × 10^6 bits = 688 KB
1. https://github.com/SystemsApproach/book/pull/81/commits/89568b7435fe5ffab2d2fb2e4efa4d734bd47afd
   1.  54 Mbps x 0.33 μs = 18 bytes
   1. 1 Gbps  x 230 ms = 230 bytes
   1. 10 Gbps x 40 ms = 400 bytes  