### PR TITLE
Fix example of ones' complement sum

### DIFF
--- a/direct/error.rst
+++ b/direct/error.rst
@@ -109,13 +109,13 @@ In ones’ complement arithmetic, a negative integer (-x) is represented
 as the complement of x; that is, each bit of x is inverted. When adding
 numbers in ones’ complement arithmetic, a carryout from the most
 significant bit needs to be added to the result. Consider, for example,
-the addition of -5 and -3 in ones’ complement arithmetic on 4-bit
-integers: +5 is 0101, so -5 is 1010; +3 is 0011, so -3 is 1100. If we
-add 1010 and 1100, ignoring the carry, we get 0110. In ones’ complement
+the addition of -5 and -2 in ones’ complement arithmetic on 4-bit
+integers: +5 is 0101, so -5 is 1010; +2 is 0010, so -2 is 1101. If we
+add 1010 and 1101, ignoring the carry, we get 0111. In ones’ complement
 arithmetic, the fact that this operation caused a carry from the most
-significant bit causes us to increment the result, giving 0111, which is
-the ones’ complement representation of -8 (obtained by inverting the
-bits in 1000), as we would expect.
+significant bit causes us to increment the result, giving 1000, which is
+the ones’ complement representation of -7 (obtained by inverting the
+bits in 0111), as we would expect.
 
 The following routine gives a straightforward implementation of the
 Internet’s checksum algorithm. The ``count`` argument gives the length


### PR DESCRIPTION
https://github.com/SystemsApproach/book/blob/dd26bf87e54ab4d55450debc175b830cb8e87386/direct/error.rst?plain=1#L108-L118

The example of ones' complement sum above is wrong because -8 cannot be represented in ones' complement arithmetic on 4-bit integers. `0111` is the representation of 7, not -8.

I propose changing the example to the sum -5 and -2.