### PR TITLE
Fixing BGP Stub Terminology

### DIFF
--- a/scaling/global.rst
+++ b/scaling/global.rst
@@ -292,11 +292,10 @@ terminates on nodes within an AS, and *transit traffic* as traffic that
 passes through an AS. We can classify autonomous systems into three
 broad types:
 
--  Stub AS—an AS that has only a single connection to one other AS; such
-   an AS will only carry local traffic. The small corporation in :numref:`Figure
-   %s <fig-inet-1995>` is an example of a stub AS.
+-  Stub AS—an AS that only carry local traffic. The small corporation in
+   :numref:`Figure %s <fig-inet-1995>` is an example of a stub AS.
 
--  Multihomed AS—an AS that has connections to more than one other AS
+-  Multihomed Stub AS—an AS that has connections to more than one other AS
    but that refuses to carry transit traffic, such as the large
    corporation at the top of :numref:`Figure %s <fig-inet-1995>`.
 


### PR DESCRIPTION
The enumeration made it look like "multi-homed" AS was a "stub" AS that also had one or more additional connections. In reality, "stub" is the property of not forwarding traffic, and "multi-homed" is a *different* property of having multiple connections.
This was hinted at in the text when talking about Stub ASes, but not made clear in the definitions.

This commit changes the definitions to hopefully make it more clear.
